### PR TITLE
Update to 0.38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:17.10
 LABEL maintainer="malvarez00@icloud.com"
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV MOTIONEYE_VERSION=0.37.1
+ENV MOTIONEYE_VERSION=0.38
 
 # Install motion, ffmpeg, v4l-utils and the dependencies from the repositories
 RUN apt-get update && \


### PR DESCRIPTION
Fixes a nasty `EOFError` when browsing media files.